### PR TITLE
Remove `#[feature(let-chanins)]` to allow build on stable rust

### DIFF
--- a/loader/src/lib.rs
+++ b/loader/src/lib.rs
@@ -101,7 +101,6 @@
 //! }
 //! ```
 
-#![feature(let_chains)]
 #![allow(clippy::new_without_default)]
 #![allow(clippy::let_and_return)]
 #![warn(missing_docs)]


### PR DESCRIPTION
Thank you for creating web-static-pack!  I use it on stable rust and have been looking forward to things in the 0.5 release.

The feature `let-chains` is stable since 1.88, so the feature annotation itself seems to be the only thing that keeps this crate from building and working on stable rust.